### PR TITLE
Updating the model to download

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ pip install -r requirements
 ```
 Download the spacy model
 ``` bash
-python -m spacy download en_core_web_sm
+python -m spacy download en_core_web_md
 ```
 ### Export the dataset
 In Doccano, go to the Datasets page and export the dataset. This will create a zip file containing the annotations per user, i.e `admin.jsonl` and `unknown.jsonl` which contains all the sections that have not been annotated yet.


### PR DESCRIPTION
Since in the script generate_train_model.py is using the 'en_core_web_md' and not 'en_core_web_sm', on the function df_to_spacy, line 26, it breaks the script.