### PR TITLE
Activating the model used

### DIFF
--- a/custom-model/config.cfg
+++ b/custom-model/config.cfg
@@ -128,8 +128,8 @@ ents_r = 0.0
 [pretraining]
 
 [initialize]
-# vectors = "en_core_web_md"
-vectors = "en_ner_bc5cdr_md"
+vectors = "en_core_web_md"
+# vectors = "en_ner_bc5cdr_md"
 init_tok2vec = ${paths.init_tok2vec}
 vocab_data = null
 lookups = null


### PR DESCRIPTION
Since in the readme and the script generate_train_file.py references en_core_web_md, it needs to comment the model en_ner_bv5cdr_md and uncomment en_core_web_md.